### PR TITLE
HCL syntax to yaml in example

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -5,18 +5,32 @@ The GitHub Action for the [Ballerina CLI](https://ballerina.io/) wraps the `ball
 ## Usage
 
 ```
-action "Ballerina Build" {
-  uses = "ballerina-platform/github-actions/cli/latest@master"
-  args = "build"
-}
+name: Ballerina example
 
-action "Ballerina Push" {
-  uses = "ballerina-platform/github-actions/cli/latest@master"
-  env = {
-    BALLERINA_CENTRAL_ACCESS_TOKEN = "Ballerina Central Access Token"
-  }
-  args = "push"
-}
+on: [push]
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+    
+      - name: Ballerina Build
+        uses: ballerina-platform/github-actions/cli/latest@master
+        with:
+          args: 
+            build
+
+      - name: Ballerina Push
+        uses: ballerina-platform/github-actions/cli/latest@master
+        with:
+          env: 
+            BALLERINA_CENTRAL_ACCESS_TOKEN = ${{ secrets.BallerinaToken }}
+          args: 
+            push 
 
 ```
 


### PR DESCRIPTION
I changed the HCL Syntax to YAML in the example. I have only tested teh Build step since I don't have a Ballerina Central token.

## Purpose
Github switched from HCL to YAML syntax and from October onwards HCL workflows will not run

## Goals
Help users using the Ballerina Github Actions 
## Approach
Changed and did a test run

## User stories
Reading the example in the Readme file will explain how to use this action with yaml syntax

## Release note
Translated example in Readme from HCL to YAML syntax

## Documentation


## Training


## Certification

## Marketing

## Automation tests

## Security checks
 
## Samples


## Related PRs


## Migrations (if applicable)

## Test environment

## Learning
